### PR TITLE
⚡ Bolt: Implement lazy-initialization and caching for API clients

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-05-22 - API Client Connection Pooling/Caching
+**Learning:** Initializing Google Cloud API clients (credential lookup + gRPC dialing) for every request is a major performance bottleneck in CLI tools, especially when fan-out operations (like listing resources across 24 regions) are performed concurrently. This leads to redundant TCP/TLS handshakes and increased latency.
+**Action:** Implement lazy-initialization and caching for gRPC/REST clients and credentials using `sync.Mutex` at the `GCPClient` level. Reusing the client across multiple requests within the same process execution significantly reduces total operation time.

--- a/internal/run/api/domainmapping/client.go
+++ b/internal/run/api/domainmapping/client.go
@@ -19,6 +19,7 @@ package domainmapping
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/JulienBreux/run-cli/internal/run/api/client"
 	"golang.org/x/oauth2/google"
@@ -59,18 +60,42 @@ type Client interface {
 }
 
 // GCPClient is the Google Cloud Platform implementation of the Client interface.
-type GCPClient struct{}
+type GCPClient struct {
+	mu     sync.Mutex
+	creds  *google.Credentials
+	client DomainMappingsClientWrapper
+}
+
+func (c *GCPClient) getClient(ctx context.Context) (DomainMappingsClientWrapper, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.client != nil {
+		return c.client, nil
+	}
+
+	if c.creds == nil {
+		creds, err := client.FindDefaultCredentials(ctx, run.CloudPlatformScope)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find default credentials: %w", err)
+		}
+		c.creds = creds
+	}
+
+	dmClient, err := createClient(ctx, c.creds)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create domain mappings client: %w", err)
+	}
+	c.client = dmClient
+
+	return c.client, nil
+}
 
 // ListDomainMappings lists domain mappings for a given project and region.
 func (c *GCPClient) ListDomainMappings(ctx context.Context, project, region string) ([]*run.DomainMapping, error) {
-	creds, err := client.FindDefaultCredentials(ctx, run.CloudPlatformScope)
+	dmClient, err := c.getClient(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find default credentials: %w", err)
-	}
-
-	dmClient, err := createClient(ctx, creds)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create domain mappings client: %w", err)
+		return nil, err
 	}
 
 	parent := fmt.Sprintf("projects/%s/locations/%s", project, region)

--- a/internal/run/api/job/client.go
+++ b/internal/run/api/job/client.go
@@ -19,11 +19,13 @@ package job
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	run "cloud.google.com/go/run/apiv2"
 	"cloud.google.com/go/run/apiv2/runpb"
 	"github.com/JulienBreux/run-cli/internal/run/api/client"
 	"github.com/googleapis/gax-go/v2"
+	"golang.org/x/oauth2/google"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 )
@@ -98,22 +100,43 @@ type Client interface {
 var _ Client = (*GCPClient)(nil)
 
 // GCPClient is the Google Cloud Platform implementation of Client.
-type GCPClient struct{}
+type GCPClient struct {
+	mu     sync.Mutex
+	creds  *google.Credentials
+	client JobsClientWrapper
+}
 
-// ListJobs lists jobs for a project and region.
-func (c *GCPClient) ListJobs(ctx context.Context, project, region string) ([]*runpb.Job, error) {
-	creds, err := client.FindDefaultCredentials(ctx, run.DefaultAuthScopes()...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find default credentials: %w", err)
+func (c *GCPClient) getClient(ctx context.Context) (JobsClientWrapper, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.client != nil {
+		return c.client, nil
 	}
 
-	cClient, err := createJobsClient(ctx, option.WithCredentials(creds))
+	if c.creds == nil {
+		creds, err := client.FindDefaultCredentials(ctx, run.DefaultAuthScopes()...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find default credentials: %w", err)
+		}
+		c.creds = creds
+	}
+
+	cClient, err := createJobsClient(ctx, option.WithCredentials(c.creds))
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		_ = cClient.Close()
-	}()
+	c.client = cClient
+
+	return c.client, nil
+}
+
+// ListJobs lists jobs for a project and region.
+func (c *GCPClient) ListJobs(ctx context.Context, project, region string) ([]*runpb.Job, error) {
+	cClient, err := c.getClient(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	req := &runpb.ListJobsRequest{
 		Parent: fmt.Sprintf("projects/%s/locations/%s", project, region),
@@ -137,18 +160,10 @@ func (c *GCPClient) ListJobs(ctx context.Context, project, region string) ([]*ru
 
 // RunJob runs a job.
 func (c *GCPClient) RunJob(ctx context.Context, name string) (*runpb.Execution, error) {
-	creds, err := client.FindDefaultCredentials(ctx, run.DefaultAuthScopes()...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find default credentials: %w", err)
-	}
-
-	cClient, err := createJobsClient(ctx, option.WithCredentials(creds))
+	cClient, err := c.getClient(ctx)
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		_ = cClient.Close()
-	}()
 
 	op, err := cClient.RunJob(ctx, &runpb.RunJobRequest{Name: name})
 	if err != nil {

--- a/internal/run/api/job/execution/execution.go
+++ b/internal/run/api/job/execution/execution.go
@@ -20,12 +20,14 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 
 	run "cloud.google.com/go/run/apiv2"
 	"cloud.google.com/go/run/apiv2/runpb"
 	"github.com/JulienBreux/run-cli/internal/run/api/client"
 	"github.com/JulienBreux/run-cli/internal/run/model/common/condition"
 	model "github.com/JulienBreux/run-cli/internal/run/model/job/execution"
+	"golang.org/x/oauth2/google"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 )
@@ -99,22 +101,43 @@ type Client interface {
 }
 
 // GCPClient is the Google Cloud Platform implementation of Client.
-type GCPClient struct{}
+type GCPClient struct {
+	mu     sync.Mutex
+	creds  *google.Credentials
+	client ExecutionsClientWrapper
+}
 
-// ListExecutions lists executions for a project, region and job.
-func (c *GCPClient) ListExecutions(ctx context.Context, project, region, jobName string) ([]*runpb.Execution, error) {
-	creds, err := client.FindDefaultCredentials(ctx, run.DefaultAuthScopes()...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find default credentials: %w", err)
+func (c *GCPClient) getClient(ctx context.Context) (ExecutionsClientWrapper, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.client != nil {
+		return c.client, nil
 	}
 
-	cClient, err := createExecutionsClient(ctx, option.WithCredentials(creds))
+	if c.creds == nil {
+		creds, err := client.FindDefaultCredentials(ctx, run.DefaultAuthScopes()...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find default credentials: %w", err)
+		}
+		c.creds = creds
+	}
+
+	cClient, err := createExecutionsClient(ctx, option.WithCredentials(c.creds))
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		_ = cClient.Close()
-	}()
+	c.client = cClient
+
+	return c.client, nil
+}
+
+// ListExecutions lists executions for a project, region and job.
+func (c *GCPClient) ListExecutions(ctx context.Context, project, region, jobName string) ([]*runpb.Execution, error) {
+	cClient, err := c.getClient(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	// Filter by job name
 	// The parent is the location. We filter by label or just iterate and filter?

--- a/internal/run/api/project/client.go
+++ b/internal/run/api/project/client.go
@@ -21,12 +21,14 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 
 	resourcemanager "cloud.google.com/go/resourcemanager/apiv3"
 	resourcemanagerpb "cloud.google.com/go/resourcemanager/apiv3/resourcemanagerpb"
 	"github.com/JulienBreux/run-cli/internal/run/api/client"
 	model "github.com/JulienBreux/run-cli/internal/run/model/common/project"
 	"github.com/googleapis/gax-go/v2"
+	"golang.org/x/oauth2/google"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 )
@@ -79,23 +81,43 @@ type Client interface {
 var _ Client = (*GCPClient)(nil)
 
 // GCPClient is the Google Cloud Platform implementation of Client.
-type GCPClient struct{}
+type GCPClient struct {
+	mu     sync.Mutex
+	creds  *google.Credentials
+	client ProjectsClientWrapper
+}
 
-// ListProjects lists projects for the current user.
-func (c *GCPClient) ListProjects(ctx context.Context) ([]model.Project, error) {
-	// Explicitly find default credentials
-	creds, err := client.FindDefaultCredentials(ctx, resourcemanager.DefaultAuthScopes()...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find default credentials: %w. Tip: Try running 'gcloud auth application-default login' to authenticate the Go client", err)
+func (c *GCPClient) getClient(ctx context.Context) (ProjectsClientWrapper, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.client != nil {
+		return c.client, nil
 	}
 
-	cClient, err := createProjectsClient(ctx, option.WithCredentials(creds))
+	if c.creds == nil {
+		creds, err := client.FindDefaultCredentials(ctx, resourcemanager.DefaultAuthScopes()...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find default credentials: %w. Tip: Try running 'gcloud auth application-default login' to authenticate the Go client", err)
+		}
+		c.creds = creds
+	}
+
+	cClient, err := createProjectsClient(ctx, option.WithCredentials(c.creds))
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		_ = cClient.Close()
-	}()
+	c.client = cClient
+
+	return c.client, nil
+}
+
+// ListProjects lists projects for the current user.
+func (c *GCPClient) ListProjects(ctx context.Context) ([]model.Project, error) {
+	cClient, err := c.getClient(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	req := &resourcemanagerpb.SearchProjectsRequest{
 		// Query: "", // Empty query lists all projects

--- a/internal/run/api/service/client.go
+++ b/internal/run/api/service/client.go
@@ -19,11 +19,13 @@ package service
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	run "cloud.google.com/go/run/apiv2"
 	"cloud.google.com/go/run/apiv2/runpb"
 	"github.com/JulienBreux/run-cli/internal/run/api/client"
 	"github.com/googleapis/gax-go/v2"
+	"golang.org/x/oauth2/google"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 )
@@ -105,22 +107,43 @@ type Client interface {
 var _ Client = (*GCPClient)(nil)
 
 // GCPClient is the Google Cloud Platform implementation of Client.
-type GCPClient struct{}
+type GCPClient struct {
+	mu     sync.Mutex
+	creds  *google.Credentials
+	client ServicesClientWrapper
+}
 
-// ListServices lists services for a project and region.
-func (c *GCPClient) ListServices(ctx context.Context, project, region string) ([]*runpb.Service, error) {
-	creds, err := client.FindDefaultCredentials(ctx, run.DefaultAuthScopes()...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find default credentials: %w", err)
+func (c *GCPClient) getClient(ctx context.Context) (ServicesClientWrapper, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.client != nil {
+		return c.client, nil
 	}
 
-	cClient, err := createServicesClient(ctx, option.WithCredentials(creds))
+	if c.creds == nil {
+		creds, err := client.FindDefaultCredentials(ctx, run.DefaultAuthScopes()...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find default credentials: %w", err)
+		}
+		c.creds = creds
+	}
+
+	cClient, err := createServicesClient(ctx, option.WithCredentials(c.creds))
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		_ = cClient.Close()
-	}()
+	c.client = cClient
+
+	return c.client, nil
+}
+
+// ListServices lists services for a project and region.
+func (c *GCPClient) ListServices(ctx context.Context, project, region string) ([]*runpb.Service, error) {
+	cClient, err := c.getClient(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	req := &runpb.ListServicesRequest{
 		Parent: fmt.Sprintf("projects/%s/locations/%s", project, region),
@@ -144,36 +167,20 @@ func (c *GCPClient) ListServices(ctx context.Context, project, region string) ([
 
 // GetService gets a single service.
 func (c *GCPClient) GetService(ctx context.Context, name string) (*runpb.Service, error) {
-	creds, err := client.FindDefaultCredentials(ctx, run.DefaultAuthScopes()...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find default credentials: %w", err)
-	}
-
-	cClient, err := createServicesClient(ctx, option.WithCredentials(creds))
+	cClient, err := c.getClient(ctx)
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		_ = cClient.Close()
-	}()
 
 	return cClient.GetService(ctx, &runpb.GetServiceRequest{Name: name})
 }
 
 // UpdateService updates a service.
 func (c *GCPClient) UpdateService(ctx context.Context, service *runpb.Service) (*runpb.Service, error) {
-	creds, err := client.FindDefaultCredentials(ctx, run.DefaultAuthScopes()...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find default credentials: %w", err)
-	}
-
-	cClient, err := createServicesClient(ctx, option.WithCredentials(creds))
+	cClient, err := c.getClient(ctx)
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		_ = cClient.Close()
-	}()
 
 	op, err := cClient.UpdateService(ctx, &runpb.UpdateServiceRequest{Service: service})
 	if err != nil {

--- a/internal/run/api/service/revision/client.go
+++ b/internal/run/api/service/revision/client.go
@@ -19,11 +19,13 @@ package revision
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	run "cloud.google.com/go/run/apiv2"
 	"cloud.google.com/go/run/apiv2/runpb"
 	"github.com/JulienBreux/run-cli/internal/run/api/client"
 	"github.com/googleapis/gax-go/v2"
+	"golang.org/x/oauth2/google"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 )
@@ -76,20 +78,43 @@ type Client interface {
 var apiClient Client = &GCPClient{}
 
 // GCPClient is the Google Cloud Platform implementation of Client.
-type GCPClient struct{}
+type GCPClient struct {
+	mu     sync.Mutex
+	creds  *google.Credentials
+	client RevisionsClientWrapper
+}
 
-// ListRevisions lists revisions for a service.
-func (c *GCPClient) ListRevisions(ctx context.Context, project, region, service string) ([]*runpb.Revision, error) {
-	creds, err := client.FindDefaultCredentials(ctx, run.DefaultAuthScopes()...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find default credentials: %w", err)
+func (c *GCPClient) getClient(ctx context.Context) (RevisionsClientWrapper, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.client != nil {
+		return c.client, nil
 	}
 
-	cClient, err := createRevisionsClient(ctx, option.WithCredentials(creds))
+	if c.creds == nil {
+		creds, err := client.FindDefaultCredentials(ctx, run.DefaultAuthScopes()...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find default credentials: %w", err)
+		}
+		c.creds = creds
+	}
+
+	cClient, err := createRevisionsClient(ctx, option.WithCredentials(c.creds))
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = cClient.Close() }()
+	c.client = cClient
+
+	return c.client, nil
+}
+
+// ListRevisions lists revisions for a service.
+func (c *GCPClient) ListRevisions(ctx context.Context, project, region, service string) ([]*runpb.Revision, error) {
+	cClient, err := c.getClient(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	req := &runpb.ListRevisionsRequest{
 		Parent: fmt.Sprintf("projects/%s/locations/%s/services/%s", project, region, service),

--- a/internal/run/api/workerpool/client.go
+++ b/internal/run/api/workerpool/client.go
@@ -19,11 +19,13 @@ package workerpool
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	run "cloud.google.com/go/run/apiv2"
 	"cloud.google.com/go/run/apiv2/runpb"
 	"github.com/JulienBreux/run-cli/internal/run/api/client"
 	"github.com/googleapis/gax-go/v2"
+	"golang.org/x/oauth2/google"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 )
@@ -104,22 +106,43 @@ type Client interface {
 var _ Client = (*GCPClient)(nil)
 
 // GCPClient is the Google Cloud Platform implementation of Client.
-type GCPClient struct{}
+type GCPClient struct {
+	mu     sync.Mutex
+	creds  *google.Credentials
+	client WorkerPoolsClientWrapper
+}
 
-// ListWorkerPools lists worker pools for a project and region.
-func (c *GCPClient) ListWorkerPools(ctx context.Context, project, region string) ([]*runpb.WorkerPool, error) {
-	creds, err := client.FindDefaultCredentials(ctx, run.DefaultAuthScopes()...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find default credentials: %w", err)
+func (c *GCPClient) getClient(ctx context.Context) (WorkerPoolsClientWrapper, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.client != nil {
+		return c.client, nil
 	}
 
-	cClient, err := createWorkerPoolsClient(ctx, option.WithCredentials(creds))
+	if c.creds == nil {
+		creds, err := client.FindDefaultCredentials(ctx, run.DefaultAuthScopes()...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find default credentials: %w", err)
+		}
+		c.creds = creds
+	}
+
+	cClient, err := createWorkerPoolsClient(ctx, option.WithCredentials(c.creds))
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		_ = cClient.Close()
-	}()
+	c.client = cClient
+
+	return c.client, nil
+}
+
+// ListWorkerPools lists worker pools for a project and region.
+func (c *GCPClient) ListWorkerPools(ctx context.Context, project, region string) ([]*runpb.WorkerPool, error) {
+	cClient, err := c.getClient(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	req := &runpb.ListWorkerPoolsRequest{
 		Parent: fmt.Sprintf("projects/%s/locations/%s", project, region),
@@ -143,36 +166,20 @@ func (c *GCPClient) ListWorkerPools(ctx context.Context, project, region string)
 
 // GetWorkerPool gets a worker pool.
 func (c *GCPClient) GetWorkerPool(ctx context.Context, name string) (*runpb.WorkerPool, error) {
-	creds, err := client.FindDefaultCredentials(ctx, run.DefaultAuthScopes()...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find default credentials: %w", err)
-	}
-
-	cClient, err := createWorkerPoolsClient(ctx, option.WithCredentials(creds))
+	cClient, err := c.getClient(ctx)
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		_ = cClient.Close()
-	}()
 
 	return cClient.GetWorkerPool(ctx, &runpb.GetWorkerPoolRequest{Name: name})
 }
 
 // UpdateWorkerPool updates a worker pool.
 func (c *GCPClient) UpdateWorkerPool(ctx context.Context, workerPool *runpb.WorkerPool) (*runpb.WorkerPool, error) {
-	creds, err := client.FindDefaultCredentials(ctx, run.DefaultAuthScopes()...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find default credentials: %w", err)
-	}
-
-	cClient, err := createWorkerPoolsClient(ctx, option.WithCredentials(creds))
+	cClient, err := c.getClient(ctx)
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		_ = cClient.Close()
-	}()
 
 	op, err := cClient.UpdateWorkerPool(ctx, &runpb.UpdateWorkerPoolRequest{WorkerPool: workerPool})
 	if err != nil {


### PR DESCRIPTION
💡 What: Implemented lazy-initialization and caching for Google Cloud API clients and credentials across all major API packages (service, job, execution, workerpool, domainmapping, project, and revision).

🎯 Why: Previously, the application created and closed a new client for every single request. This was particularly inefficient when listing resources across all regions (e.g., 24 regions), resulting in redundant credential lookups and gRPC connection establishment overhead (TCP/TLS handshakes, gRPC dialing).

📊 Impact: Significantly reduces latency for multiple API calls, especially concurrent regional listings. Reuses gRPC connections and avoids redundant authentication overhead.

🔬 Measurement: Verified with a temporary test that `createServicesClient` is only called once for multiple `ListServices` calls. All existing tests passed.

---
*PR created automatically by Jules for task [1632207965586736866](https://jules.google.com/task/1632207965586736866) started by @JulienBreux*