### PR TITLE
⚡ Bolt: Standardize context.Background() inside lazy GCPClient initialization

### DIFF
--- a/internal/run/api/domainmapping/client.go
+++ b/internal/run/api/domainmapping/client.go
@@ -65,6 +65,9 @@ type GCPClient struct {
 	client DomainMappingsClientWrapper
 }
 
+// getClient lazily initializes and returns the cached DomainMappingsClientWrapper in a thread-safe manner.
+// Using context.Background() ensures the credentials and clients remain valid and are not canceled
+// with individual short-lived request contexts.
 func (c *GCPClient) getClient(ctx context.Context) (DomainMappingsClientWrapper, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -73,12 +76,13 @@ func (c *GCPClient) getClient(ctx context.Context) (DomainMappingsClientWrapper,
 		return c.client, nil
 	}
 
-	creds, err := client.FindDefaultCredentials(ctx, run.CloudPlatformScope)
+	bgCtx := context.Background()
+	creds, err := client.FindDefaultCredentials(bgCtx, run.CloudPlatformScope)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find default credentials: %w", err)
 	}
 
-	dmClient, err := createClient(ctx, creds)
+	dmClient, err := createClient(bgCtx, creds)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create domain mappings client: %w", err)
 	}

--- a/internal/run/api/job/client.go
+++ b/internal/run/api/job/client.go
@@ -104,6 +104,9 @@ type GCPClient struct {
 	client JobsClientWrapper
 }
 
+// getClient lazily initializes and returns the cached JobsClientWrapper in a thread-safe manner.
+// Using context.Background() ensures the credentials and clients remain valid and are not canceled
+// with individual short-lived request contexts.
 func (c *GCPClient) getClient(ctx context.Context) (JobsClientWrapper, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -112,12 +115,13 @@ func (c *GCPClient) getClient(ctx context.Context) (JobsClientWrapper, error) {
 		return c.client, nil
 	}
 
-	creds, err := client.FindDefaultCredentials(ctx, run.DefaultAuthScopes()...)
+	bgCtx := context.Background()
+	creds, err := client.FindDefaultCredentials(bgCtx, run.DefaultAuthScopes()...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find default credentials: %w", err)
 	}
 
-	cClient, err := createJobsClient(ctx, option.WithCredentials(creds))
+	cClient, err := createJobsClient(bgCtx, option.WithCredentials(creds))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/run/api/workerpool/client.go
+++ b/internal/run/api/workerpool/client.go
@@ -110,6 +110,9 @@ type GCPClient struct {
 	client WorkerPoolsClientWrapper
 }
 
+// getClient lazily initializes and returns the cached WorkerPoolsClientWrapper in a thread-safe manner.
+// Using context.Background() ensures the credentials and clients remain valid and are not canceled
+// with individual short-lived request contexts.
 func (c *GCPClient) getClient(ctx context.Context) (WorkerPoolsClientWrapper, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -118,12 +121,13 @@ func (c *GCPClient) getClient(ctx context.Context) (WorkerPoolsClientWrapper, er
 		return c.client, nil
 	}
 
-	creds, err := client.FindDefaultCredentials(ctx, run.DefaultAuthScopes()...)
+	bgCtx := context.Background()
+	creds, err := client.FindDefaultCredentials(bgCtx, run.DefaultAuthScopes()...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find default credentials: %w", err)
 	}
 
-	cClient, err := createWorkerPoolsClient(ctx, option.WithCredentials(creds))
+	cClient, err := createWorkerPoolsClient(bgCtx, option.WithCredentials(creds))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/run/tui/app/app_test.go
+++ b/internal/run/tui/app/app_test.go
@@ -322,11 +322,10 @@ func TestShortcuts_Modals(t *testing.T) {
 	// --- Service Modals ---
 	currentPageID = service.LIST_PAGE_ID
 	svcTable := service.List(app).Table
-	// Populate with full struct for Describe/Scale
-	service.Load([]model_service.Service{{Name: "s1", Region: "r1"}})
-	svcTable.Select(1, 0)
 	
 	// Log
+	service.Load([]model_service.Service{{Name: "s1", Region: "r1"}})
+	svcTable.Select(1, 0)
 	shortcuts(tcell.NewEventKey(tcell.KeyRune, 'l', tcell.ModNone))
 	assert.Equal(t, log.MODAL_PAGE_ID, currentPageID)
 	// Close modal to reset
@@ -334,6 +333,8 @@ func TestShortcuts_Modals(t *testing.T) {
 	currentPageID = service.LIST_PAGE_ID
 	
 	// Describe
+	service.Load([]model_service.Service{{Name: "s1", Region: "r1"}})
+	svcTable.Select(1, 0)
 	shortcuts(tcell.NewEventKey(tcell.KeyRune, 'd', tcell.ModNone))
 	assert.Equal(t, describe.MODAL_PAGE_ID, currentPageID)
 	rootPages.RemovePage(describe.MODAL_PAGE_ID)


### PR DESCRIPTION
💡 What: Standardized lazy-initialization contexts for GCPClient wrappers.
🎯 Why: Using transient request-scoped contexts for credential lookup and client construction binds the cached client's underlying gRPC/REST connection pool and credentials logic to short-lived contexts. If a request is cancelled, future operations on the cached client can fail, causing performance degradation and unstable connection pools.
📊 Impact: Ensures shared connection pool longevity, preventing transport teardowns and credentials re-discovery.
🔬 Measurement: Verified using unit tests and codebase pattern consistency.

---
*PR created automatically by Jules for task [7887510388541538168](https://jules.google.com/task/7887510388541538168) started by @JulienBreux*